### PR TITLE
Have GitHub actions authoring the commits

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -18,8 +18,8 @@ jobs:
       working-directory: benchmark/
     - name: Commit and push changes
       run: |
-        git config --global user.name "jasperhabicht"
-        git config --global user.email "mail@jasperhabicht.de"
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
         git add benchmark/README.md
         git add benchmark/benchmark.pdf
         git commit -m "Update benchmark results (Action)"


### PR DESCRIPTION
I think, it is better to have GitHub actions shown as author. Example for "my" repository

![image](https://github.com/user-attachments/assets/076dda38-4a14-481f-9029-7bd09c0155d9)
